### PR TITLE
Release v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.2.5 — 2025-08-30
+
+* up (2a63117) — MordilloSan
+* update (ee3ef0f) — MordilloSan
+
+_Compare: https://github.com/https://github.com/mordilloSan/LinuxIO/compare/v0.2.4...v0.2.5_
+
 ## v0.2.4 — 2025-08-30
 
 * up (01c0c3b) — MordilloSan

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 # Main flags
 VITE_DEV_PORT = 3000
 SERVER_PORT = 8080
-VERBOSE ?= false
+VERBOSE ?= true
 
 # Go and Node.js versions
 GO_VERSION      = 1.25.0
@@ -181,14 +181,14 @@ setup: ensure-go ensure-node ensure-golint
 	'
 	@echo "✅ Frontend dependencies installed!"
 
-lint:
+lint: setup
 	@echo "🔍 Running ESLint..."
 	@bash -c '\
 		cd frontend && \
 		npx eslint src --ext .js,.jsx,.ts,.tsx --fix && echo "✅ frontend Linting Ok!" \
 	'
 
-tsc:
+tsc: setup
 	@echo "🔍 Running TypeScript type checks..."
 	@bash -c '\
 		cd frontend && \

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 # Main flags
 VITE_DEV_PORT = 3000
 SERVER_PORT = 8080
-VERBOSE ?= true
+VERBOSE ?= false
 
 # Go and Node.js versions
 GO_VERSION      = 1.25.0


### PR DESCRIPTION
## v0.2.5 — 2025-08-30

* up (2a63117) — MordilloSan
* update (ee3ef0f) — MordilloSan

_Compare: https://github.com/https://github.com/mordilloSan/LinuxIO/compare/v0.2.4...v0.2.5_

## v0.2.4 — 2025-08-30

* up (01c0c3b) — MordilloSan
* docs(changelog): add notes for v0.2.4 (161e8c4) — MordilloSan
* update (8582066) — MordilloSan

_Compare: https://github.com/https://github.com/mordilloSan/LinuxIO/compare/v0.2.3...v0.2.4_

## v0.2.4 — 2025-08-30

* update (8582066) — MordilloSan

_Compare: https://github.com/https://github.com/mordilloSan/LinuxIO/compare/v0.2.3...v0.2.4_

## v0.2.2 — 2025-08-30

* docs(changelog): add notes for v0.2.2 (acd66b8) — MordilloSan
* docs(changelog): add notes for v0.2.2 (2a41273) — MordilloSan
* docs(changelog): add notes for v0.2.2 (5037b09) — MordilloSan
* docs(changelog): add notes for v0.2.2 (43f27fe) — MordilloSan
* chore(release): add release notes for v0.2.2 (1e70b11) — MordilloSan
* chore(release): add release notes for v0.2.2 (364b838) — MordilloSan
* docs(changelog): add notes for v0.2.2 (bc2bc48) — MordilloSan
* chore(release): add release notes for v0.2.2 (ed70660) — MordilloSan
* node update on workflow (cbd74d6) — MordilloSan
* bug fix (d23cd10) — MordilloSan
* session restructure (8e8b661) — MordilloSan
* global API code (a1ee919) — MordilloSan

_Compare: https://github.com/https://github.com/mordilloSan/LinuxIO/compare/v0.2.1...v0.2.2_

