### PR TITLE
Release v0.2.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 
+## v0.2.26 — 2025-10-15
+
+### 🐛 Bug Fixes
+
+* fix: app update bug ([ff05a09](https://github.com/owner/repo/commit/ff05a09)) by @MordilloSan
+
+### 👥 Contributors
+
+* @MordilloSan
+
+**Full Changelog**: https://github.com/owner/repo/compare/v0.2.25...v0.2.26
+
+
 ## v0.2.25 — 2025-10-15
 
 ### 🚀 Features

--- a/backend/bridge/handlers/control/control.go
+++ b/backend/bridge/handlers/control/control.go
@@ -154,17 +154,19 @@ func performUpdate(targetVersion string) (UpdateResult, error) {
 }
 
 func runInstallScript(version string) error {
-	logger.Infof("[update] executing: curl -fsSL %s | sudo bash -s -- %s", InstallScriptURL, version)
-	cmdStr := fmt.Sprintf("curl -fsSL %s | sudo bash -s -- %s", InstallScriptURL, version)
-
-	cmd := exec.Command("bash", "-c", cmdStr)
-	output, err := cmd.CombinedOutput()
+	tmp := "/tmp/linuxio-install.sh"
+	if out, err := exec.Command("bash", "-c",
+		fmt.Sprintf("curl -fsSL %s -o %s", InstallScriptURL, tmp)).CombinedOutput(); err != nil {
+		logger.Errorf("[update] download failed:\n%s", string(out))
+		return fmt.Errorf("download failed: %w", err)
+	}
+	cmd := exec.Command("sudo", "bash", tmp, version)
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		logger.Errorf("[update] installation failed:\n%s", string(output))
+		logger.Errorf("[update] installation failed:\n%s", string(out))
 		return fmt.Errorf("script execution failed: %w", err)
 	}
-
-	logger.Infof("[update] installation output:\n%s", string(output))
+	logger.Infof("[update] installation output:\n%s", string(out))
 	return nil
 }
 

--- a/packaging/scripts/install-linuxio-binaries.sh
+++ b/packaging/scripts/install-linuxio-binaries.sh
@@ -254,7 +254,7 @@ main() {
 
 # ---------- Usage ----------
 
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+if [[ -z "${BASH_SOURCE+x}" || "${BASH_SOURCE[0]-}" == "$0" ]]; then
     if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
         cat <<EOF
 Usage: $(basename "$0") [VERSION]


### PR DESCRIPTION

## v0.2.26 — 2025-10-15

### 🐛 Bug Fixes

* fix: app update bug ([ff05a09](https://github.com/owner/repo/commit/ff05a09)) by @MordilloSan

### 👥 Contributors

* @MordilloSan

**Full Changelog**: https://github.com/owner/repo/compare/v0.2.25...v0.2.26


## v0.2.25 — 2025-10-15

### 🚀 Features

* feat: Footer Versioning fix: coherence of axios and react query ([688e6a4](https://github.com/owner/repo/commit/688e6a4)) by @MordilloSan

### 🐛 Bug Fixes

* fix: linting ([51219db](https://github.com/owner/repo/commit/51219db)) by @MordilloSan

### 👥 Contributors

* @MordilloSan

**Full Changelog**: https://github.com/owner/repo/compare/v0.2.24...v0.2.25


## v0.2.24 — 2025-10-15

### 🐛 Bug Fixes

* fix: update script ([375c008](https://github.com/owner/repo/commit/375c008)) by @MordilloSan

### 👥 Contributors

* @MordilloSan

**Full Changelog**: https://github.com/owner/repo/compare/v0.2.23...v0.2.24


## v0.2.23 — 2025-10-15

### 🔄 Other Changes

* debug: app update script bug ([6ec2a6d](https://github.com/owner/repo/commit/6ec2a6d)) by @MordilloSan

### 👥 Contributors

* @MordilloSan

**Full Changelog**: https://github.com/owner/repo/compare/v0.2.22...v0.2.23


## v0.2.22 — 2025-10-15

### 🚀 Features

* feat: changelog workflow ([cd66905](https://github.com/owner/repo/commit/cd66905)) by @MordilloSan
* feat: changelog improvement ([a6bf61e](https://github.com/owner/repo/commit/a6bf61e)) by @MordilloSan
* feat: go mod tidy ([fd7e18c](https://github.com/owner/repo/commit/fd7e18c)) by @MordilloSan

### 🐛 Bug Fixes

* fix: changelog bugfix ([c40678e](https://github.com/owner/repo/commit/c40678e)) by @MordilloSan
* fix: changelog fix ([4f4ec0c](https://github.com/owner/repo/commit/4f4ec0c)) by @MordilloSan

### 🔄 Other Changes

* app update bug fix ([4cd0e2f](https://github.com/owner/repo/commit/4cd0e2f)) by @MordilloSan
* changelog improvement ([3ca6a26](https://github.com/owner/repo/commit/3ca6a26)) by @MordilloSan
* dependencie updates ([7d7d499](https://github.com/owner/repo/commit/7d7d499)) by @MordilloSan
* makefile update ([85077dd](https://github.com/owner/repo/commit/85077dd)) by @MordilloSan
* changelog fix ([cc6e6a6](https://github.com/owner/repo/commit/cc6e6a6)) by @MordilloSan
* fix makefile bug ([371d714](https://github.com/owner/repo/commit/371d714)) by @MordilloSan

### 👥 Contributors

* @MordilloSan

**Full Changelog**: https://github.com/owner/repo/compare/v0.2.21...v0.2.22


## v0.2.21 — 2025-10-14

### 🔄 Other Changes

* go reportcard readme update ([1d18b5e](https://github.com/owner/repo/commit/1d18b5e)) by @MordilloSan
* testing workflow and general linting ([0456cce](https://github.com/owner/repo/commit/0456cce)) by @MordilloSan
* app update fix attempt ([9c49eed](https://github.com/owner/repo/commit/9c49eed)) by @MordilloSan
* readme update ([af60e75](https://github.com/owner/repo/commit/af60e75)) by @MordilloSan
* linting ([d441960](https://github.com/owner/repo/commit/d441960)) by @MordilloSan
* Merge pull request #19 from mordilloSan/dev/v0.2.21 ([3ee685b](https://github.com/owner/repo/commit/3ee685b)) by @mordillo

### 👥 Contributors

* @MordilloSan
* @mordillo


**Full Changelog**: https://github.com/owner/repo/compare/v0.2.20...v0.2.21

## v0.2.20 — 2025-10-14

### 🔄 Other Changes

* Atualizar o go.mod ([9ca7f8e](https://github.com/owner/repo/commit/9ca7f8e)) by @mordillo
* go path fix ([01c0a4f](https://github.com/owner/repo/commit/01c0a4f)) by @MordilloSan
* go path bug fix ([ce91a24](https://github.com/owner/repo/commit/ce91a24)) by @MordilloSan
* Merge pull request #18 from mordilloSan/dev/v0.2.20 ([ae8459d](https://github.com/owner/repo/commit/ae8459d)) by @mordillo

### 👥 Contributors

* @MordilloSan
* @mordillo


**Full Changelog**: https://github.com/owner/repo/compare/v0.2.16...v0.2.20

## v0.2.16 — 2025-10-14

### 🔄 Other Changes

* app update bugfix ([58bbe18](https://github.com/owner/repo/commit/58bbe18)) by @MordilloSan
* file permissions bug ([6312ef3](https://github.com/owner/repo/commit/6312ef3)) by @MordilloSan
* Merge pull request #17 from mordilloSan/dev/v0.2.16 ([1e6dc95](https://github.com/owner/repo/commit/1e6dc95)) by @mordillo

### 👥 Contributors

* @MordilloSan
* @mordillo


**Full Changelog**: https://github.com/owner/repo/compare/v0.2.15...v0.2.16

## v0.2.15 — 2025-10-14

### 🔄 Other Changes

* makefile merge workflow update ([7755ee9](https://github.com/owner/repo/commit/7755ee9)) by @MordilloSan
* toast duration fix ([03ebea8](https://github.com/owner/repo/commit/03ebea8)) by @MordilloSan
* Merge pull request #16 from mordilloSan/dev/v0.2.15 ([1295494](https://github.com/owner/repo/commit/1295494)) by @mordillo

### 👥 Contributors

* @MordilloSan
* @mordillo


**Full Changelog**: https://github.com/owner/repo/compare/v0.2.14...v0.2.15

## v0.2.14 — 2025-10-14

### 🔄 Other Changes

* app autoupdate ([55d7168](https://github.com/owner/repo/commit/55d7168)) by @MordilloSan
* Merge pull request #15 from mordilloSan/dev/v0.2.14 ([e3f37a7](https://github.com/owner/repo/commit/e3f37a7)) by @mordillo

### 👥 Contributors

* @MordilloSan
* @mordillo


**Full Changelog**: https://github.com/owner/repo/compare/v0.2.13...v0.2.14

## v0.2.13 — 2025-10-14

### 🔄 Other Changes

* update banner ([65baf24](https://github.com/owner/repo/commit/65baf24)) by @MordilloSan
* makefile update ([a410fd3](https://github.com/owner/repo/commit/a410fd3)) by @MordilloSan
* makefile update ([917e569](https://github.com/owner/repo/commit/917e569)) by @MordilloSan
* Merge pull request #13 from mordilloSan/dev/v0.2.12 ([0203e18](https://github.com/owner/repo/commit/0203e18)) by @mordillo
* makefile update ([e1c9825](https://github.com/owner/repo/commit/e1c9825)) by @MordilloSan
* makefile update ([ee1d3d0](https://github.com/owner/repo/commit/ee1d3d0)) by @MordilloSan
* Merge pull request #14 from mordilloSan/dev/v0.2.13 ([fe97083](https://github.com/owner/repo/commit/fe97083)) by @mordillo

### 👥 Contributors

* @MordilloSan
* @mordillo


**Full Changelog**: https://github.com/owner/repo/compare/v0.2.12...v0.2.13

## v0.2.12 — 2025-10-14

### 🔄 Other Changes

* Bump github.com/quic-go/quic-go from 0.54.0 to 0.54.1 in /backend ([c58abf4](https://github.com/owner/repo/commit/c58abf4)) by @dependabot[bot]
* Merge branch 'main' into dependabot/go_modules/backend/github.com/quic-go/quic-go-0.54.1 ([93d0426](https://github.com/owner/repo/commit/93d0426)) by @mordillo
* Merge remote-tracking branch 'origin/dependabot/go_modules/backend/github.com/quic-go/quic-go-0.54.1' into dev/v0.2.12 ([acf2e52](https://github.com/owner/repo/commit/acf2e52)) by @MordilloSan
* Merge branch 'main' into dependabot/go_modules/backend/github.com/quic-go/quic-go-0.54.1 ([e33c26b](https://github.com/owner/repo/commit/e33c26b)) by @mordillo
* Merge pull request #6 from mordilloSan/dependabot/go_modules/backend/github.com/quic-go/quic-go-0.54.1 ([ce141c8](https://github.com/owner/repo/commit/ce141c8)) by @mordillo
* install process and makefile optimization ([b9cdf2d](https://github.com/owner/repo/commit/b9cdf2d)) by @MordilloSan
* makefile update ([d226403](https://github.com/owner/repo/commit/d226403)) by @MordilloSan
* makefile upgrade ([9c1f218](https://github.com/owner/repo/commit/9c1f218)) by @MordilloSan
* makefile upgrade ([e484b97](https://github.com/owner/repo/commit/e484b97)) by @MordilloSan
* makefile upgrade ([e91edb8](https://github.com/owner/repo/commit/e91edb8)) by @MordilloSan
* makefile upgrade ([0ba88c0](https://github.com/owner/repo/commit/0ba88c0)) by @MordilloSan
* up ([ed13d0b](https://github.com/owner/repo/commit/ed13d0b)) by @MordilloSan
* update ([76e32ec](https://github.com/owner/repo/commit/76e32ec)) by @MordilloSan
* make update ([5a22e8f](https://github.com/owner/repo/commit/5a22e8f)) by @MordilloSan
* bug fix ([b69ceb9](https://github.com/owner/repo/commit/b69ceb9)) by @MordilloSan
* bug fix ([cdadb91](https://github.com/owner/repo/commit/cdadb91)) by @MordilloSan
* test ([fcec6db](https://github.com/owner/repo/commit/fcec6db)) by @MordilloSan
* bug fix ([2bc290f](https://github.com/owner/repo/commit/2bc290f)) by @MordilloSan
* up ([a87101d](https://github.com/owner/repo/commit/a87101d)) by @MordilloSan
* up ([d76e08b](https://github.com/owner/repo/commit/d76e08b)) by @MordilloSan
* bug fix ([9fc5a78](https://github.com/owner/repo/commit/9fc5a78)) by @MordilloSan
* bug fix ([29bfb26](https://github.com/owner/repo/commit/29bfb26)) by @MordilloSan
* bug fix ([981bacc](https://github.com/owner/repo/commit/981bacc)) by @MordilloSan
* Merge pull request #12 from mordilloSan/dev/v0.2.12 ([2ec37b3](https://github.com/owner/repo/commit/2ec37b3)) by @mordillo

### 👥 Contributors

* @MordilloSan
* @dependabot[bot]
* @mordillo


**Full Changelog**: https://github.com/owner/repo/compare/v0.2.11...v0.2.12

## v0.2.11 — 2025-10-13

### 🔄 Other Changes

* updatebanner bug ([26d0e10](https://github.com/owner/repo/commit/26d0e10)) by @MordilloSan
* Merge pull request #11 from mordilloSan/dev/v0.2.11 ([8e4ff6e](https://github.com/owner/repo/commit/8e4ff6e)) by @mordillo

### 👥 Contributors

* @MordilloSan
* @mordillo


**Full Changelog**: https://github.com/owner/repo/compare/v0.2.10...v0.2.11

## v0.2.10 — 2025-10-13

### 🔄 Other Changes

* version API ([8b7add0](https://github.com/owner/repo/commit/8b7add0)) by @MordilloSan
* Merge pull request #10 from mordilloSan/dev/v0.2.10 ([38b6c7f](https://github.com/owner/repo/commit/38b6c7f)) by @mordillo

### 👥 Contributors

* @MordilloSan
* @mordillo


**Full Changelog**: https://github.com/owner/repo/compare/v0.2.9...v0.2.10

## v0.2.9 — 2025-10-13

### 🔄 Other Changes

* app update procedure ([49c3ef1](https://github.com/owner/repo/commit/49c3ef1)) by @MordilloSan
* linting fix ([c05e15d](https://github.com/owner/repo/commit/c05e15d)) by @MordilloSan
* Merge pull request #9 from mordilloSan/dev/v0.2.9 ([6471ea3](https://github.com/owner/repo/commit/6471ea3)) by @mordillo

### 👥 Contributors

* @MordilloSan
* @mordillo


**Full Changelog**: https://github.com/owner/repo/compare/v0.2.8...v0.2.9

## v0.2.8 — 2025-10-13

### 🔄 Other Changes

* automatic updates ([61ccf00](https://github.com/owner/repo/commit/61ccf00)) by @MordilloSan
* linting ([6048b8d](https://github.com/owner/repo/commit/6048b8d)) by @MordilloSan
* Merge pull request #8 from mordilloSan/dev/v0.2.8 ([5fc9044](https://github.com/owner/repo/commit/5fc9044)) by @mordillo

### 👥 Contributors

* @MordilloSan
* @mordillo


**Full Changelog**: https://github.com/owner/repo/compare/v0.2.6...v0.2.8

## v0.2.6 — 2025-10-11

### 📚 Documentation

* docs: update changelog for v0.2.6 ([8e4829a](https://github.com/owner/repo/commit/8e4829a)) by @MordilloSan
* docs: update changelog for v0.2.6 ([c7c95b9](https://github.com/owner/repo/commit/c7c95b9)) by @MordilloSan

### 🔄 Other Changes

* versioning update ([84590ec](https://github.com/owner/repo/commit/84590ec)) by @MordilloSan
* websocket ([6f0f9e0](https://github.com/owner/repo/commit/6f0f9e0)) by @MordilloSan
* env cleanup ([4305bbe](https://github.com/owner/repo/commit/4305bbe)) by @MordilloSan
* env bug fix ([8020e12](https://github.com/owner/repo/commit/8020e12)) by @MordilloSan
* env bug fix ([b0d34c6](https://github.com/owner/repo/commit/b0d34c6)) by @MordilloSan
* socket determination update enviorment variables removal C helper update ([0c9c973](https://github.com/owner/repo/commit/0c9c973)) by @MordilloSan
* changelog update ([8dedd7c](https://github.com/owner/repo/commit/8dedd7c)) by @MordilloSan
* changelog update ([25e114f](https://github.com/owner/repo/commit/25e114f)) by @MordilloSan
* makefile changelog code ([7bc5046](https://github.com/owner/repo/commit/7bc5046)) by @MordilloSan
* makefile bugfix ([bbcb515](https://github.com/owner/repo/commit/bbcb515)) by @MordilloSan
* makefile improvement ([0bf2ad8](https://github.com/owner/repo/commit/0bf2ad8)) by @MordilloSan
* makefile update ([c49e945](https://github.com/owner/repo/commit/c49e945)) by @MordilloSan
* changelog update ([1ac238f](https://github.com/owner/repo/commit/1ac238f)) by @MordilloSan
* pull request workflow ([a6c0382](https://github.com/owner/repo/commit/a6c0382)) by @MordilloSan
* Merge pull request #7 from mordilloSan/dev/v0.2.6 ([f2a54d7](https://github.com/owner/repo/commit/f2a54d7)) by @mordillo

### 👥 Contributors

* @MordilloSan
* @github-actions[bot]
* @mordillo


**Full Changelog**: https://github.com/owner/repo/compare/v0.2.5...v0.2.6

## v0.2.5 — 2025-10-09

### 🔄 Other Changes

* package updater refreshed ([0bb7a92](https://github.com/owner/repo/commit/0bb7a92)) by @MordilloSan
* Merge pull request #5 from mordilloSan/dev/v0.2.5 ([a530b05](https://github.com/owner/repo/commit/a530b05)) by @mordillo

### 👥 Contributors

* @MordilloSan
* @github-actions[bot]
* @mordillo


**Full Changelog**: https://github.com/owner/repo/compare/v0.2.3...v0.2.5

## v0.2.3 — 2025-10-08

### 🔄 Other Changes

* testing update ([a26ffb0](https://github.com/owner/repo/commit/a26ffb0)) by @MordilloSan
* golinting update ([304d5f8](https://github.com/owner/repo/commit/304d5f8)) by @MordilloSan
* github workflow update ([8eb8383](https://github.com/owner/repo/commit/8eb8383)) by @MordilloSan
* linting update ([052a9d1](https://github.com/owner/repo/commit/052a9d1)) by @MordilloSan
* Merge pull request #4 from mordilloSan/dev/v0.2.3 ([a677459](https://github.com/owner/repo/commit/a677459)) by @mordillo

### 👥 Contributors

* @MordilloSan
* @github-actions[bot]
* @mordillo


**Full Changelog**: https://github.com/owner/repo/compare/v0.2.2...v0.2.3

## v0.2.2 — 2025-10-08

### 🔄 Other Changes

* pullrequest testing workflow update ([462bf3c](https://github.com/owner/repo/commit/462bf3c)) by @MordilloSan
* makefile bugfix ([c96f47c](https://github.com/owner/repo/commit/c96f47c)) by @MordilloSan
* test workflow ([06d95fe](https://github.com/owner/repo/commit/06d95fe)) by @MordilloSan
* update to the workflow ([6baed35](https://github.com/owner/repo/commit/6baed35)) by @MordilloSan
* Merge pull request #3 from mordilloSan/dev/v0.2.2 ([40bcd3a](https://github.com/owner/repo/commit/40bcd3a)) by @mordillo

### 👥 Contributors

* @MordilloSan
* @github-actions[bot]
* @mordillo


**Full Changelog**: https://github.com/owner/repo/compare/v0.2.1...v0.2.2

## v0.2.1 — 2025-10-08

### 🔄 Other Changes

* codeql unit conversion fixes ([5a6b011](https://github.com/owner/repo/commit/5a6b011)) by @MordilloSan
* Merge pull request #2 from mordilloSan/dev/v0.2.1 ([3af2818](https://github.com/owner/repo/commit/3af2818)) by @mordillo

### 👥 Contributors

* @MordilloSan
* @github-actions[bot]
* @mordillo


**Full Changelog**: https://github.com/owner/repo/compare/v0.2.0...v0.2.1

## v0.2.0 — 2025-10-08

### 🐛 Bug Fixes

* fix(ci): exclude bot commits from changelog generation ([b870c42](https://github.com/owner/repo/commit/b870c42)) by @MordilloSan

### 🔄 Other Changes

* Update to the changelog workflow ([d9bac52](https://github.com/owner/repo/commit/d9bac52)) by @MordilloSan
* readme update ([857bc16](https://github.com/owner/repo/commit/857bc16)) by @MordilloSan
* makefile update ([5ff8ee6](https://github.com/owner/repo/commit/5ff8ee6)) by @MordilloSan
* makefile bugfix ([9d41405](https://github.com/owner/repo/commit/9d41405)) by @MordilloSan
* Merge pull request #1 from mordilloSan/dev/v0.2.0 ([53a87b5](https://github.com/owner/repo/commit/53a87b5)) by @mordillo

### 👥 Contributors

* @MordilloSan
* @github-actions[bot]
* @mordillo


**Full Changelog**: https://github.com/owner/repo/compare/v0.1.0...v0.2.0

## v0.1.0 — 2025-10-08

### 🔄 Other Changes

* Initial commit - LinuxIO v0.1.0 ([a8180e2](https://github.com/owner/repo/commit/a8180e2)) by @MordilloSan
* update ([a6f3cab](https://github.com/owner/repo/commit/a6f3cab)) by @MordilloSan
* update ([5712112](https://github.com/owner/repo/commit/5712112)) by @MordilloSan
* update ([de4f213](https://github.com/owner/repo/commit/de4f213)) by @MordilloSan

### 👥 Contributors

* @MordilloSan


**Full Changelog**: https://github.com/owner/repo/compare/...v0.1.0
