### PR TITLE
Release v0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 
+## v0.5.5 — 2025-12-22
+
+### 🐛 Bug Fixes
+
+* fix: - bug fix with namespace for auth-helper ([6bafdca](https://github.com/mordilloSan/LinuxIO/commit/6bafdca)) by @MordilloSan
+
+### 👥 Contributors
+
+* @MordilloSan
+
+**Full Changelog**: https://github.com/mordilloSan/LinuxIO/compare/v0.5.4...v0.5.5
+
+
 ## v0.5.4 — 2025-12-22
 
 ### 🚀 Features

--- a/packaging/systemd/linuxio.service
+++ b/packaging/systemd/linuxio.service
@@ -27,14 +27,14 @@ ProtectClock=true
 ProtectHostname=true
 LockPersonality=true
 MemoryDenyWriteExecute=true
-RestrictNamespaces=true
+RestrictNamespaces=false
 RestrictRealtime=true
 DevicePolicy=closed
 PrivateDevices=true
 UMask=0027
 ReadOnlyPaths=/etc/linuxio
 RemoveIPC=true
-SystemCallFilter=~@keyring @cpu-emulation @debug @module @mount @obsolete @raw-io @reboot @swap
+SystemCallFilter=~@keyring @cpu-emulation @debug @module @obsolete @raw-io @reboot @swap
 SystemCallErrorNumber=EPERM
 
 [Install]


### PR DESCRIPTION
## v0.5.5 — 2025-12-22

### 🐛 Bug Fixes

* fix: - bug fix with namespace for auth-helper ([6bafdca](https://github.com/mordilloSan/LinuxIO/commit/6bafdca)) by @MordilloSan

### 👥 Contributors

* @MordilloSan

**Full Changelog**: https://github.com/mordilloSan/LinuxIO/compare/v0.5.4...v0.5.5


