### PR TITLE
Release v0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
 
+## v0.5.6 — 2025-12-22
+
+### 🐛 Bug Fixes
+
+* fix: - bug fix with namespace for auth-helper ([6bafdca](https://github.com/mordilloSan/LinuxIO/commit/6bafdca)) by @MordilloSan
+
+### 🔄 Other Changes
+
+* Merge pull request #58 from mordilloSan/dev/v0.5.5 ([59a6b9d](https://github.com/mordilloSan/LinuxIO/commit/59a6b9d)) by @mordillo
+
+### 👥 Contributors
+
+* @MordilloSan
+* @mordillo
+
+**Full Changelog**: https://github.com/mordilloSan/LinuxIO/compare/v0.5.4...v0.5.6
+
+
 ## v0.5.5 — 2025-12-22
 
 ### 🐛 Bug Fixes


### PR DESCRIPTION
## v0.5.6 — 2025-12-22

### 🐛 Bug Fixes

* fix: - bug fix with namespace for auth-helper ([6bafdca](https://github.com/mordilloSan/LinuxIO/commit/6bafdca)) by @MordilloSan

### 🔄 Other Changes

* Merge pull request #58 from mordilloSan/dev/v0.5.5 ([59a6b9d](https://github.com/mordilloSan/LinuxIO/commit/59a6b9d)) by @mordillo

### 👥 Contributors

* @MordilloSan
* @mordillo

**Full Changelog**: https://github.com/mordilloSan/LinuxIO/compare/v0.5.4...v0.5.6


